### PR TITLE
remove hardcoded verbose 3 parameter

### DIFF
--- a/board/balena-fin/balena-fin-v1-1.cfg
+++ b/board/balena-fin/balena-fin-v1-1.cfg
@@ -1,5 +1,4 @@
 adapter driver sysfsgpio
-debug_level 3
 # Set parameters for Balena Fin
 sysfsgpio_tdi_num 11
 sysfsgpio_tdo_num 25


### PR DESCRIPTION
this is now supported as a dynamic parameter by openocd (`-d` from CLI and `debug_level` from telnet client) so there is no need to have it hardcoded. Plus, when set to 3 it floods stdout with quite the logstream using a non marginal chunk of CPU and FS I/O
