### PR TITLE
Update balena-fin-v1-0.cfg

### DIFF
--- a/board/balena-fin/balena-fin-v1-0.cfg
+++ b/board/balena-fin/balena-fin-v1-0.cfg
@@ -1,7 +1,11 @@
 adapter driver ftdi
 transport select swd
+adapter speed 1000
 ftdi vid_pid 0x0403 0x6010
 
 ftdi layout_init 0x0098 0x05fb
 ftdi layout_signal SWD_EN -data 0
 ftdi layout_signal nSRST -data 0x0080
+
+set CHIPNAME efm32
+source [find target/efm32.cfg]

--- a/board/balena-fin/balena-fin-v1-0.cfg
+++ b/board/balena-fin/balena-fin-v1-0.cfg
@@ -1,7 +1,7 @@
 adapter driver ftdi
 transport select swd
-ftdi_vid_pid 0x0403 0x6010
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_layout_init 0x0098 0x05fb
-ftdi_layout_signal SWD_EN -data 0
-ftdi_layout_signal nSRST -data 0x0080
+ftdi layout_init 0x0098 0x05fb
+ftdi layout_signal SWD_EN -data 0
+ftdi layout_signal nSRST -data 0x0080

--- a/board/balena-fin/balena-fin-v1-0.cfg
+++ b/board/balena-fin/balena-fin-v1-0.cfg
@@ -1,11 +1,7 @@
 adapter driver ftdi
 transport select swd
-adapter speed 1000
 ftdi vid_pid 0x0403 0x6010
 
 ftdi layout_init 0x0098 0x05fb
 ftdi layout_signal SWD_EN -data 0
 ftdi layout_signal nSRST -data 0x0080
-
-set CHIPNAME efm32
-source [find target/efm32.cfg]


### PR DESCRIPTION
when run against openocd v0.11, the following deprecation errors are returned:

```
Open On-Chip Debugger 0.11.0+dev-gae6de2f-dirty (2021-07-24-13:59)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
debug_level: 2

Info : FTDI SWD mode enabled
DEPRECATED! use 'ftdi vid_pid' not 'ftdi_vid_pid'
DEPRECATED! use 'ftdi layout_init' not 'ftdi_layout_init'
DEPRECATED! use 'ftdi layout_signal' not 'ftdi_layout_signal'
DEPRECATED! use 'ftdi layout_signal' not 'ftdi_layout_signal'
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Error: An adapter speed is not selected in the init script. Insert a call to "adapter speed" or "jtag_rclk" to proceed.
```